### PR TITLE
Remove trailing semicolon in livingstyleguide exec command

### DIFF
--- a/index.coffee
+++ b/index.coffee
@@ -26,7 +26,7 @@ module.exports = (options = {}) ->
       return next()
 
     styleguideFilePath = file.path.replace /\..*$/g, ''
-    exec "bundle exec livingstyleguide compile #{file.path};", (error, stdout, stderr) =>
+    exec "bundle exec livingstyleguide compile #{file.path}", (error, stdout, stderr) =>
       if error
         err = new gutil.PluginError PLUGIN_NAME, error
         @emit 'error', err


### PR DESCRIPTION
Having a semicolon at the end of the command makes it fail in Windows
with a ENOENT error.

Fixes: https://github.com/efacilitation/gulp-livingstyleguide/issues/5